### PR TITLE
fix(threatrace): align reproduction with paper algorithm (3 bugs)

### DIFF
--- a/config/threatrace.yml
+++ b/config/threatrace.yml
@@ -20,7 +20,7 @@ feat_inference:
 
 batching:
   save_on_disk: False
-  node_features: node_type,edges_distribution
+  node_features: edges_distribution
   edge_features: none
   fix_buggy_graph_reindexer: False
   global_batching:

--- a/pidsmaker/detection/evaluation_methods/node_evaluation.py
+++ b/pidsmaker/detection/evaluation_methods/node_evaluation.py
@@ -183,27 +183,32 @@ def get_node_predictions_node_level(val_tw_path, test_tw_path, cfg, **kwargs):
         flash_label = 0
         detected_tw = None
         if cfg.evaluation.node_evaluation.threshold_method == "threatrace":
-            max_score = 0
-            pred_score = max(losses["threatrace_score"])
+            # Original ThreaTrace (IEEE TIFS'22, Eq 1 + train_darpatc.py):
+            # anomaly  <=>  (ratio < thre)  OR  (predicted_type != ground_truth_type)
+            # i.e. low confidence OR wrong prediction => anomaly.
+            # Track the most "anomalous" (lowest-score) signal across time windows.
+            min_score = float('inf')
+            pred_score = min(losses["threatrace_score"])
 
             for score, node_type_pred, tw in zip(
                 losses["threatrace_score"], losses["correct_pred"], losses["tw"]
             ):
-                if score > thr and node_type_pred and score > max_score:
+                if (score < thr or not node_type_pred) and score < min_score:
                     threatrace_label = 1
-                    max_score = score
+                    min_score = score
                     detected_tw = tw
 
         elif cfg.evaluation.node_evaluation.threshold_method == "flash":
-            max_score = 0
-            pred_score = max(losses["flash_score"])
+            # Same confidence-based logic as threatrace branch.
+            min_score = float('inf')
+            pred_score = min(losses["flash_score"])
 
             for score, node_type_pred, tw in zip(
                 losses["flash_score"], losses["correct_pred"], losses["tw"]
             ):
-                if score > thr and node_type_pred and score > max_score:
+                if (score < thr or not node_type_pred) and score < min_score:
                     flash_label = 1
-                    max_score = score
+                    min_score = score
                     detected_tw = tw
 
         elif cfg.evaluation.node_evaluation.threshold_method == "magic":

--- a/pidsmaker/utils/data_utils.py
+++ b/pidsmaker/utils/data_utils.py
@@ -210,14 +210,15 @@ def extract_msg_from_data(
         max_num_nodes = max([torch.cat([g.src, g.dst]).max().item() for g in data_set]) + 1
         x_distrib = torch.zeros(max_num_nodes, edge_type_dim * 2, dtype=torch.float)
 
+    # Always parse the user-declared feature list first
+    selected_node_feats = list(
+        map(lambda x: x.strip(), selected_node_feats.replace("-", ",").split(","))
+    )
+    # only_type / only_ones mean "no learned embedding"; drop only node_emb, keep the rest
     if only_type:
-        selected_node_feats = ["node_type"]
+        selected_node_feats = [f for f in selected_node_feats if f != "node_emb"] or ["node_type"]
     elif only_ones:
-        selected_node_feats = ["only_ones"]
-    else:
-        selected_node_feats = list(
-            map(lambda x: x.strip(), selected_node_feats.replace("-", ",").split(","))
-        )
+        selected_node_feats = [f for f in selected_node_feats if f != "node_emb"] or ["only_ones"]
 
     edge_features = list(map(lambda x: x.strip(), cfg.batching.edge_features.split(",")))
     possible_triplets = get_possible_triplets(cfg) if "edge_type_triplet" in edge_features else None


### PR DESCRIPTION
The current PIDSMaker reproduction of ThreaTrace (IEEE TIFS'22) deviates from the paper algorithm in three places that compound to turn the detector into a trivial classifier with reversed anomaly semantics. This patch restores faithful semantics. All three changes are mutually dependent — fixing only one or two leaves the detector misbehaving (see discussion in the PR description).

Bug 1 — only_type silently drops other node features
  config/threatrace.yml sets `node_features: node_type,edges_distribution`,
  but pidsmaker/utils/data_utils.py overwrites the parsed list with
  `["node_type"]` whenever `featurization.used_method == "only_type"`,
  silently dropping `edges_distribution`. Fix: parse the user-declared
  list first, then strip only `node_emb` when no learned embedding is
  available — preserving `edges_distribution` (and any other declared
  feature).

Bug 2 — input contains the prediction target (label leakage)
  With Bug 1 fixed, the input still concatenates `node_type` (3-d one-hot
  of the target class) with `edges_distribution`, while the decoder is
  `predict_node_type`. The model reads the answer from its input and the
  task degenerates. ThreaTrace Eq 1 defines features as `F: V → ℕ^{2·Ne}`,
  i.e. edges_distribution only (20-d for E3 datasets, 2·Ne with Ne=10
  edge types). Fix: drop `node_type` from `batching.node_features` in
  config/threatrace.yml so the decoder must actually infer node type
  from neighborhood edge distribution, as the paper intends.

Bug 3 — anomaly formula has both inequality and boolean reversed
  pidsmaker/detection/evaluation_methods/node_evaluation.py used
  `(score > thr) AND (correct_pred == 1)`, which flags the most-confident
  correctly-predicted nodes — the opposite of an anomaly signal.
  ThreaTrace's published algorithm (paper Eq 1 + original
  `train_darpatc.py` / `Threatrace_Cadets_Contorter.ipynb:269`) is:
      anomaly  ⇔  (top1_prob / top2_prob  <  threshold)
               OR (predicted_type  ≠  declared_type)
  i.e. low confidence OR wrong prediction. Because PIDSMaker stores
  `score = log(top1/top2)` and the threshold is computed in the same log
  space, this becomes `(score < thr) OR (not correct_pred)`. Fix applied
  to both the `threatrace` and `flash` branches, switching score tracking
  from max to min. The `magic` (reconstruction) branch is left alone —
  its semantics are different (high reconstruction loss = anomaly).

Evidence (CADETS_E3 1-day demo, 12 epochs, CPU; full logs in PR):

Note up front: on this under-trained demo the standard ML metrics *regress* after the fix. That regression is the expected consequence of restoring the paper-correct (stricter) anomaly semantics on a 1-day training budget; the qualitative evidence below explains why the fix is nonetheless correct.

Standard ML metrics (the honest bad news):

                        before fix    after fix     direction
  precision             0.00068       0.00040       ↓ (worse)
  recall                1.0           0.783         ↓ (worse)
  fscore                0.00135       0.00081       ↓ (worse)
  auc                   0.750         0.587         ↓ (worse)
  adp_score (best)      0.051         0.001         ↓ (worse)
  tp / fp / fn / tn     60/88690/0/   47/116256/
                        42748         13/15182
  percent_detected_atks 1.0           1.0           = (unchanged)

Structural / mechanistic evidence (why the fix is still right):

                        before fix    after fix
  input dim             3             20            ← matches paper Eq 1 (2·Ne, Ne=10)
                        (node_type)   (edges_distribution)
  train_loss  (ep11)    0.221         0.619         ← no longer fits leaked answer
  val_loss    (ep11)    0.968         1.007
  train↔val gap         0.747         0.388         ← overfitting reduced
  mean score malicious  7.65          1.14          ← paper expects malicious=low-conf
  mean score benign     5.17          1.05
  malicious < thr=1.5   0 / 60        47 / 60       ← paper-correct flag set
  benign  > thr=1.5     100%          12.1%         ← model learned benign confidence tail
  fp_in_malicious_tw    0.032         0.019         ← FPs less attack-aligned

Reading the evidence together:

  Before the fix every malicious node has *high* confidence (mean 7.65),
  because with input = node_type (Bug 1) and decoder = predict_node_type
  (Bug 2) the model is a trivial identity classifier — input *is* the
  answer. The reversed anomaly formula (Bug 3) then flags
  high-confidence + correct nodes, which by coincidence contains the
  attack nodes, producing an artificially perfect recall = 1.0 and
  auc = 0.75. That number is not evidence the detector works; it is
  evidence three bugs are masking each other.

  After the fix the input is 20-d edges_distribution, the decoder must
  infer node type from neighborhood edge distribution, and the anomaly
  rule keys off low confidence + wrong prediction. The trained model
  now exhibits the textbook ThreaTrace separation: 47/60 malicious
  fall below the 1.5 threshold (low confidence as the paper expects)
  while 12.1% of benign develop a high-confidence long tail. The
  remaining 13 malicious that score above 1.5 are why recall drops to
  0.78 on this run; the FP explosion is because 87.9% of benign are
  also below 1.5 (the model has not had enough training data to
  separate them). Both effects are about training scale, not algorithm
  correctness: at paper-scale 7-day training the benign-side long tail
  tightens and absolute metrics are expected to recover.

References:
  - Paper: ThreaTrace (IEEE TIFS'22), Eq 1
  - Original code: utils_cadets/train_darpatc.py, Threatrace_Cadets_Contorter.ipynb line 269