### PR TITLE
Fix FLASH Word2Vec corpus iteration

### DIFF
--- a/pidsmaker/featurization/featurization_methods/featurization_flash.py
+++ b/pidsmaker/featurization/featurization_methods/featurization_flash.py
@@ -82,8 +82,7 @@ class RepeatableIterator:
 
     def __iter__(self):
         for phrases in self.data:
-            for sentence in phrases:
-                yield sentence
+            yield phrases
 
 
 def main(cfg):


### PR DESCRIPTION
## Summary

- Fix the FLASH Word2Vec corpus iterator to yield complete token sequences.
- Prevent the iterator from yielding individual tokens instead of Word2Vec sentences.