### PR TITLE
fix(preprocessing): enforce canonical event ordering

### DIFF
--- a/pidsmaker/preprocessing/build_graph_methods/build_default_graphs.py
+++ b/pidsmaker/preprocessing/build_graph_methods/build_default_graphs.py
@@ -255,7 +255,7 @@ def gen_edge_fused_tw(indexid2msg, cfg):
             select * from event_table
             where
                   timestamp_rec>'%s' and timestamp_rec<'%s'
-                   ORDER BY timestamp_rec, event_uuid;
+                   ORDER BY timestamp_rec ASC, _id ASC;
             """ % (start_ns_timestamp, end_ns_timestamp)
             cur.execute(sql)
             events = cur.fetchall()


### PR DESCRIPTION
## Summary

- Enforce deterministic event ordering in the default graph builder.
- Replace `ORDER BY timestamp_rec, event_uuid` with `ORDER BY timestamp_rec ASC, _id ASC`.
- Leave the MAGIC graph builder unchanged.

## Rationale

The tracked event-table schema defines `_id` as the row-level primary key. Ordering by `(timestamp_rec ASC, _id ASC)` provides a stable tie-breaker for events that share the same timestamp and aligns the default graph builder with the canonical event-order contract.

## Scope

- One commit.
- One production file.
- One insertion and one deletion.
- No changes to the MAGIC graph builder.
- No database, preprocessing, graph construction, training, inference, or runtime evaluation was performed as part of this change.

## Validation

- Commit: `08ee720fcdae565a7d7fe41a40dd973e6c8b191b`
- Target: `pidsmaker/preprocessing/build_graph_methods/build_default_graphs.py`
- Static source hashes and the committed diff were verified.
- The cross-fork comparison confirms exactly one changed file and the authorized SQL replacement.

## Limitations

Runtime canonical-order behavior and restored CADETS/THEIA schema applicability remain unconfirmed without database-catalog and runtime evidence.